### PR TITLE
RE-2250 Generate placeholder release notes

### DIFF
--- a/gating/generate_release_notes/run
+++ b/gating/generate_release_notes/run
@@ -15,3 +15,5 @@
 # release notes should be formatted with GitHub-flavoured Markdown.
 # RE_HOOK_REPO_HTTP_URL: The URL for the repository being released e.g.
 # https://github.com/rcbops/rpc-openstack.git.
+
+echo "Release notes generation has not been implemented for ${RE_HOOK_REPO_HTTP_URL}" > $RE_HOOK_RELEASE_NOTES


### PR DESCRIPTION
If the release notes script doesn't generate a release notes file,
the release process fails. This commit ensures that a place holder
release notes file is generated.