### PR TITLE
Prevent deploying OSA specific MTC bits on non-OSA deployments

### DIFF
--- a/playbooks/generate-environment-vars.yml
+++ b/playbooks/generate-environment-vars.yml
@@ -61,10 +61,18 @@
       when:
         - http_proxy_server != 'none://none:none'
 
+    - name: Register product variable
+      stat:
+        path: /etc/openstack-release
+      register: rpco_product
+      when:
+        - stat.exists == True
+
     - name: Ensure environment files directory exists
       file:
         path: "{{ var_location }}/env.d"
         state: directory
+      when: rpco_product is defined
 
     - name: Copy environment files
       copy:
@@ -73,6 +81,7 @@
       with_items:
         - elk.yml
         - fleet.yml
+      when: rpco_product is defined
 
     - name: Find log_hosts entries
       find:
@@ -82,6 +91,7 @@
         patterns: "*.yml"
         recurse: yes
       register: log_hosts_entries
+      when: rpco_product is defined
 
     - name: Set files fact
       set_fact:
@@ -91,6 +101,7 @@
           {%   set _ = paths.append(item['path']) %}
           {% endfor %}
           {{ paths }}
+      when: rpco_product is defined
 
     - name: Check for basic host line
       fail:
@@ -99,6 +110,7 @@
           and 'kolide_hosts' configuration manually to continue. file with complex input
           line [ {{ item }} ], line in question [ {{ lookup('file', item) | regex_search("^log_hosts:.*", multiline=True) }} ].
       when:
+        - rpco_product is defined
         - lookup('file', item) | regex_search("^log_hosts:\s\*", multiline=True)
       with_items: "{{ config_files }}"
 
@@ -108,12 +120,14 @@
         line: 'log_hosts: &log_hosts'
         regexp: '^log_hosts.*'
       with_items: "{{ config_files }}"
+      when: rpco_product is defined
 
     - name: Add kolide_hosts entries
       lineinfile:
         path: "{{ item }}"
         line: 'kolide_hosts: *log_hosts'
       with_items: "{{ config_files }}"
+      when: rpco_product is defined
 
     - name: Add kolide secrets
       lineinfile:
@@ -121,6 +135,7 @@
         line: "{{ item }}: {{ lookup('password', '/dev/null length=20') }}"
         regexp: "^{{ item }}.*"
       when:
+        - rpco_product is defined
         - not (lookup('file', '/etc/openstack_deploy/user_secrets.yml') | regex_search("^" + item + ".*", multiline=True))
       with_items:
         - "kolide_fleet_db_password"


### PR DESCRIPTION
Registers a variable looking for `/etc/openstack-release` to prevent attempting to create files on Ceph and OSP deployments.