### PR TITLE
Lessons learned from INSIGHTS-505

### DIFF
--- a/playbooks/generate-environment-vars.yml
+++ b/playbooks/generate-environment-vars.yml
@@ -34,6 +34,8 @@
     no_proxy_hosts:
       - localhost
       - 127.0.0.1
+      - "{{ internal_lb_vip_address }}"
+      - "{{ external_lb_vip_address }}"
       - "{{ ((groups['rabbitmq_all'] | default([])) | union((groups['log_containers'] | default([])))) | map('extract', hostvars, 'ansible_host') | list | join(',') }}"
     all_var_location:
       osa: "/etc/openstack_deploy"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -77,6 +77,11 @@ fi
 # Source the ops repo
 if [[ ! -d "/opt/openstack-ansible-ops" ]]; then
   git clone https://github.com/openstack/openstack-ansible-ops /opt/openstack-ansible-ops
+elif [[ ! -d "/opt/openstack-ansible-ops/bootstrap-embedded-ansible" ]]; then
+  pushd /opt/openstack-ansible-ops
+    git fetch --all
+    git reset --hard origin/master
+  popd
 fi
 
 pushd /opt/openstack-ansible-ops/bootstrap-embedded-ansible


### PR DESCRIPTION
- Update no_proxy to include `{{ internal_lb_vip_address }}` and `{{ external_lb_vip_address }}`.
- Validate `/opt/openstack-ansible-ops/bootstrap-embedded-ansible` exists if `/opt/openstack-ansible-ops` was already present during execution of setup.sh.