### PR TITLE
Add OSP inventory cache

### DIFF
--- a/scripts/set-vars.sh
+++ b/scripts/set-vars.sh
@@ -43,7 +43,11 @@ else
 fi
 
 if [[ -d "/home/stack" ]] && [[ -f "/bin/tripleo-ansible-inventory" ]]; then
-  export OSP_PATH=""  # unimplemented
+  export OSP_PATH="${OSP_PATH:-/opt/rpc-maas}"
+  export STACK_HOME="${STACK_HOME:-/home/stack}"
+  export MTC_VARS_PATH="${STACK_HOME}"
+  source "${STACK_HOME}/stackrc"
+  export OS_CACERT="${OS_CACERT:-/etc/pki/tls/certs/ca-bundle.crt}"
 fi
 
 # Append limit blacklist to the runtime

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -60,21 +60,29 @@ else
     if [[ -f "${OSA_PATH}/inventory/dynamic_inventory.py" ]]; then
       ANSIBLE_INVENTORY="${OSA_PATH}/inventory/dynamic_inventory.py" \
         "${HOME}/ansible_venv/bin/ansible-inventory" --vars \
-                                                    --yaml \
-                                                    --export \
-                                                    --list > /tmp/inventory-cache.yml
+                                                     --yaml \
+                                                     --export \
+                                                     --list > /tmp/inventory-cache.yml
     elif [[ -f "${OSA_PATH}/playbooks/inventory/dynamic_inventory.py" ]]; then
       ANSIBLE_INVENTORY="${OSA_PATH}/playbooks/inventory/dynamic_inventory.py" \
         "${HOME}/ansible_venv/bin/ansible-inventory" --vars \
-                                                    --yaml \
-                                                    --export \
-                                                    --list > /tmp/inventory-cache.yml
+                                                     --yaml \
+                                                     --export \
+                                                     --list > /tmp/inventory-cache.yml
     fi
-    # Set the ansible inventory
     export ANSIBLE_INVENTORY="/tmp/inventory-cache.yml,/opt/openstack-ansible-ops/overlay-inventories/osa-integration-inventory.yml"
     if [[ -f "/etc/openstack_deploy/inventory.ini" ]]; then
       export ANSIBLE_INVENTORY="/etc/openstack_deploy/inventory.ini,${ANSIBLE_INVENTORY}"
     fi
+
+  elif [[ -d "/home/stack" ]] && [[ -f "/bin/tripleo-ansible-inventory" ]]; then
+        ANSIBLE_INVENTORY="${OSP_PATH}/inventory/rpcr_dynamic_inventory.py" \
+          "${HOME}/ansible_venv/bin/ansible-inventory" --vars \
+                                                       --yaml \
+                                                       --export \
+                                                       --list > /tmp/inventory-cache.yml
+    # Set the ansible inventory
+    export ANSIBLE_INVENTORY="/tmp/inventory-cache.yml,/opt/openstack-ansible-ops/overlay-inventories/osa-integration-inventory.yml"
   fi
 
   # Set ceph ansible inventory


### PR DESCRIPTION
This change adds the ability to provide an inventory-cache source from
OSP deployments into the MTC workspace.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>