### PR TITLE
Fix var_location path in common task

### DIFF
--- a/playbooks/common-tasks/setup_secrets.yml
+++ b/playbooks/common-tasks/setup_secrets.yml
@@ -12,5 +12,5 @@
     regexp: "^{{ item }}.*"
   ignore_errors: true
   when:
-    - not (lookup('file', '{{ var_psth }}/user_tools_secrets.yml') | regex_search("^" + item + ".*", multiline=True))
+    - not (lookup('file', var_location + '/user_tools_secrets.yml') | regex_search("^" + item + ".*", multiline=True))
   with_items: "{{ mtc_password_items }}"


### PR DESCRIPTION
This change properly defines the variables used to drop user secrets
within generate-environment-vars.yml

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>