### PR TITLE
Add support for authenticated proxies

### DIFF
--- a/playbooks/generate-environment-vars.yml
+++ b/playbooks/generate-environment-vars.yml
@@ -27,8 +27,8 @@
   gather_facts: no
   vars:
     http_proxy_server: "none://none:none"
-    java_http_proxy: "{{ (http_proxy_server).split('://')[-1].strip('/') }}"
-    java_https_proxy: "{{ (https_proxy_server | default(http_proxy_server)).split('://')[-1].strip('/') }}"
+    java_http_proxy: "{{ (http_proxy_server).split('://')[-1].split('@')[-1].split(':')[0].strip('/') }}"
+    java_https_proxy: "{{ (https_proxy_server | default(http_proxy_server))[-1].split('@')[-1].split(':')[0].strip('/') }}"
     java_http_proxy_port: "{{ (http_proxy_server).split(':')[-1].strip('/') }}"
     java_https_proxy_port: "{{ (https_proxy_server | default(http_proxy_server)).split(':')[-1].strip('/') }}"
     no_proxy_hosts:

--- a/playbooks/generate-environment-vars.yml
+++ b/playbooks/generate-environment-vars.yml
@@ -90,6 +90,24 @@
       when:
         - not config_dir.stat.exists | bool
 
+    - name: Java auth proxy variables
+      block:
+        - name: Set variable path location
+          set_fact:
+            java_http_proxy_user: "{{ http_proxy_server.split('://')[-1].split('@')[0].split(':')[0] }}"
+            java_http_proxy_pass: "{{ http_proxy_server.split('://')[-1].split('@')[0].split(':')[-1] }}"
+          when:
+            - http_proxy_server is defined
+
+        - name: Set variable path location
+          set_fact:
+            java_https_proxy_user: "{{ (https_proxy_server | default(http_proxy_server)).split('://')[-1].split('@')[0].split(':')[0] }}"
+            java_https_proxy_pass: "{{ (https_proxy_server | default(http_proxy_server)).split('://')[-1].split('@')[0].split(':')[-1] }}"
+          when:
+            - (https_proxy_server is defined) or (http_proxy_server is defined)
+      when:
+        - ("@" in http_proxy_server) or ("@" in https_proxy_server | default(http_proxy_server))
+
     - name: Create user_tools_variables.yml
       template:
         src: templates/user_tools_variables.yml.j2

--- a/playbooks/generate-environment-vars.yml
+++ b/playbooks/generate-environment-vars.yml
@@ -27,10 +27,10 @@
   gather_facts: no
   vars:
     http_proxy_server: "none://none:none"
-    java_http_proxy: "{{ (http_proxy_server).split(':')[1].strip('/') }}"
-    java_https_proxy: "{{ (https_proxy_server | default(http_proxy_server)).split(':')[1].strip('/') }}"
-    java_http_proxy_port: "{{ (http_proxy_server).split(':')[2].strip('/') }}"
-    java_https_proxy_port: "{{ (https_proxy_server | default(http_proxy_server)).split(':')[2].strip('/') }}"
+    java_http_proxy: "{{ (http_proxy_server).split('://')[-1].strip('/') }}"
+    java_https_proxy: "{{ (https_proxy_server | default(http_proxy_server)).split('://')[-1].strip('/') }}"
+    java_http_proxy_port: "{{ (http_proxy_server).split(':')[-1].strip('/') }}"
+    java_https_proxy_port: "{{ (https_proxy_server | default(http_proxy_server)).split(':')[-1].strip('/') }}"
     no_proxy_hosts:
       - localhost
       - 127.0.0.1

--- a/playbooks/generate-environment-vars.yml
+++ b/playbooks/generate-environment-vars.yml
@@ -28,7 +28,7 @@
   vars:
     http_proxy_server: "none://none:none"
     java_http_proxy: "{{ (http_proxy_server).split('://')[-1].split('@')[-1].split(':')[0].strip('/') }}"
-    java_https_proxy: "{{ (https_proxy_server | default(http_proxy_server))[-1].split('@')[-1].split(':')[0].strip('/') }}"
+    java_https_proxy: "{{ (https_proxy_server | default(http_proxy_server)).split('://')[-1].split('@')[-1].split(':')[0].strip('/') }}"
     java_http_proxy_port: "{{ (http_proxy_server).split(':')[-1].strip('/') }}"
     java_https_proxy_port: "{{ (https_proxy_server | default(http_proxy_server)).split(':')[-1].strip('/') }}"
     no_proxy_hosts:

--- a/playbooks/templates/user_tools_variables.yml.j2
+++ b/playbooks/templates/user_tools_variables.yml.j2
@@ -44,6 +44,18 @@ deployment_environment_variables:
     -Dhttps.proxyHost={{ java_https_proxy }}
     -Dhttp.proxyPort={{ java_http_proxy_port }}
     -Dhttps.proxyPort={{ java_https_proxy_port }}
+{%   if java_http_proxy_user is defined %}
+    -Dhttp.proxyUser={{ java_http_proxy_user }}
+{%   endif %}
+{%   if java_https_proxy_user is defined %}
+    -Dhttps.proxyUser={{ java_https_proxy_user }}
+{%   endif %}
+{%   if java_http_proxy_pass is defined %}
+    -Dhttp.proxyPassword={{ java_http_proxy_pass }}
+{%   endif %}
+{%   if java_http_proxy_pass is defined %}
+    -Dhttps.proxyPassword={{ java_https_proxy_pass }}
+{%   endif %}
 {% endif %}
 
 {% raw %}


### PR DESCRIPTION
This change will now parse the proxy URL for both http and https. If the
proxy url has an "@" sign within it it will enable authenticated proxy
support. This has been setup such that it will check for authenticated
proxies for both http and https independently as a deployment may have
an authenicated proxy for specific protocols.

Signed-off-by: cloudnull <kevin@cloudnull.com>