### PR TITLE
Update overlay to add older ceph inventories to the hosts group

### DIFF
--- a/overlay-inventory.yml
+++ b/overlay-inventory.yml
@@ -12,7 +12,20 @@ all_systems:
       children:
         physical_hosts:
           children:
-            hosts: {}
+            hosts:
+              ceph_all:
+                children:
+                  mons_hosts:
+                    children:
+                      mons: {}
+
+                  osds_hosts:
+                    children:
+                      osds: {}
+
+                  rgws_hosts:
+                    children:
+                      rgws: {}
 
     all_metering:
       children:
@@ -99,20 +112,6 @@ all_systems:
         rsyslog_all:
           children:
             rsyslog: {}
-
-        ceph_all:
-          children:
-            mons_hosts:
-              children:
-                mons: {}
-
-            osds_hosts:
-              children:
-                osds: {}
-
-            rgws_hosts:
-              children:
-                rgws: {}
 
         traefik_all:
           children:


### PR DESCRIPTION
This change allows environments with minimal ceph-ansible inventories to
be pulled into the standard 'hosts' group for deploying agents and
host specific checks.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>