### PR TITLE
Fix ceph_all groups as hosts children

### DIFF
--- a/overlay-inventory.yml
+++ b/overlay-inventory.yml
@@ -13,19 +13,20 @@ all_systems:
         physical_hosts:
           children:
             hosts:
-              ceph_all:
-                children:
-                  mons_hosts:
-                    children:
-                      mons: {}
+              children:
+                ceph_all:
+                  children:
+                    mons_hosts:
+                      children:
+                        mons: {}
 
-                  osds_hosts:
-                    children:
-                      osds: {}
+                    osds_hosts:
+                      children:
+                        osds: {}
 
-                  rgws_hosts:
-                    children:
-                      rgws: {}
+                    rgws_hosts:
+                      children:
+                        rgws: {}
 
     all_metering:
       children:


### PR DESCRIPTION
Adds children under hosts for ceph_all groups.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>