### PR TITLE
Provide consistent user_tools_variables.yml with subsequent setup.sh runs

### DIFF
--- a/playbooks/templates/user_tools_variables.yml.j2
+++ b/playbooks/templates/user_tools_variables.yml.j2
@@ -34,11 +34,10 @@ haproxy_extra_services:
 
 {% if (http_proxy_server is defined) and (http_proxy_server != "none://none:none") %}
 # Proxy Variables
-extra_no_proxy_hosts: "{{ extra_no_proxy_hosts | default('') }}"
 deployment_environment_variables:
   http_proxy: "{{ http_proxy_server }}"
   https_proxy: "{{ https_proxy_server | default(http_proxy_server) }}"
-  no_proxy: "{{ no_proxy_hosts | join(',') }},{{ extra_no_proxy_hosts | default('') }}"
+  no_proxy: "{{ no_proxy_hosts | union(extra_no_proxy_hosts.split(',') | default('')) | join(',') | default('') }}"
   ES_JAVA_OPTS: >-
     -Dhttp.proxyHost={{ java_http_proxy }}
     -Dhttps.proxyHost={{ java_https_proxy }}

--- a/scripts/set-vars.sh
+++ b/scripts/set-vars.sh
@@ -22,6 +22,9 @@ export ANSIBLE_EXTRA_VARS="${ANSIBLE_EXTRA_VARS:-}"
 # Environment variable to append options to MTC pip commands
 export PIP_INSTALL_OPTS="${PIP_INSTALL_OPTS:-}"
 
+# Export pre-existing no_proxy variable
+export ORIG_NO_PROXY="$(env | awk -F= '/^no_proxy/ {print $NF}')"
+
 # Determine OS and validate curl is installed
 if [[ -f "/etc/os-release" ]]; then
   source /etc/os-release

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -122,4 +122,5 @@ ansible-playbook ${ANSIBLE_EXTRA_VARS:-} ${MTC_BLACKLIST} -i "${ANSIBLE_INVENTOR
 # Generate the required variables
 ansible-playbook ${ANSIBLE_EXTRA_VARS:-} ${MTC_BLACKLIST} -i "${ANSIBLE_INVENTORY:-localhost,}" \
                  -e "http_proxy_server=${http_proxy:-'none://none:none'}" \
+                 -e "extra_no_proxy_hosts=${ORIG_NO_PROXY:-''}" \
                  ${MTC_PLAYBOOK_DIR}/generate-environment-vars.yml


### PR DESCRIPTION
This change attempts to provide a consistent return of
user_tools_variables.yml by snapshotting the no_proxy environment
variable prior to execution and using it to extrapolate
deployment_environment_variables.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>