### PR TITLE
Prioritize inventory-ceph.yml when present

### DIFF
--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -91,7 +91,9 @@ else
   fi
 
   # Set ceph ansible inventory
-  if [[ -f "/tmp/inventory-ceph.ini" ]]; then
+  if [[ -f "/tmp/inventory-ceph.yml" ]]; then
+    export ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY},/tmp/inventory-ceph.yml"
+  elif [[ -f "/tmp/inventory-ceph.ini" ]]; then
     export ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY},/tmp/inventory-ceph.ini"
   fi
 


### PR DESCRIPTION
ceph-ansible deployments switched to a YAML style inventory file.
If the YAML style inventory is present, it will be prioritized
over the legacy ini style format